### PR TITLE
Honor CacheControl: no-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ Cache-Control: public, max-age=300
 
 Cache scope may be `public` (shared by all users) or `private` (cached per-user).  Specify `max-age` in seconds.
 
+Cache re-validation is not yet supported, so
+
+```
+Cache-Control: no-store
+```
+
+and
+
+```
+Cache-Control: no-cache
+```
+
+currently have the same effect.
+
 ## Sample Applications
 
 There are several sample applications in [this repo](https://github.com/drewwills/soffit-samples).

--- a/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorController.java
+++ b/src/main/java/org/apereo/portal/soffit/connector/SoffitConnectorController.java
@@ -225,7 +225,13 @@ public class SoffitConnectorController implements ApplicationContextAware {
             final String cacheControlValue = cacheControlHeader.getValue();
             logger.debug("Soffit with serviceUrl='{}' specified cache-control header value='{}'",
                                                                 serviceUrl, cacheControlValue);
-            if (!cacheControlValue.equals(SoffitRendererController.CACHE_CONTROL_NOCACHE)) {
+            if (cacheControlValue.equals(
+                SoffitRendererController.CACHE_CONTROL_NOSTORE)) {
+              logger.trace("Not caching response because no-store CacheControl directive.");
+            } else if (cacheControlValue.equals(
+                SoffitRendererController.CACHE_CONTROL_NOCACHE)) {
+              logger.info("Treating a no-cache directive (which would allow caching so long as cached responses are validated with the back-end at future use) as a no-store directive because do not yet support cache re-validation.");
+            } else { // neither no-cache nor no-store 
                 CacheTuple cacheTuple = null;
                 // TODO:  Need to find a polished utility that parses a cache-control header, or write one
                 final String[] tokens = cacheControlValue.split(",");

--- a/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
+++ b/src/main/java/org/apereo/portal/soffit/renderer/SoffitRendererController.java
@@ -43,6 +43,11 @@ public class SoffitRendererController {
      * specified).
      */
     public static final String CACHE_CONTROL_NOCACHE = "no-cache";
+    
+    /**
+     * Indicates the response should not be cached.
+     */
+    public static final String CACHE_CONTROL_NOSTORE = "no-store";
 
     /**
      * Prefix for all custom properties.
@@ -142,6 +147,8 @@ public class SoffitRendererController {
                 ? cacheScopeValue + ", max-age=" + cacheMaxAgeValue
                 : CACHE_CONTROL_NOCACHE;
         logger.debug("Setting cache-control='{}' for module '{}'", cacheControl, module);
+        
+        // TODO: support setting CacheControl no-store
 
         res.setHeader(Headers.CACHE_CONTROL.getName(), cacheControl);
 


### PR DESCRIPTION
Adds support in the client for honoring `CacheControl: no-store` if set on the response from the remote portlet, though does not add support for setting that CacheControl in the remote portlet.
