### PR TITLE
Promote visibility of SoffitConnectorController logger to protected.

### DIFF
--- a/src/main/java/org/apereo/portlet/soffit/connector/SoffitConnectorController.java
+++ b/src/main/java/org/apereo/portlet/soffit/connector/SoffitConnectorController.java
@@ -95,7 +95,7 @@ public class SoffitConnectorController implements ApplicationContextAware {
     @Qualifier(value="org.apereo.portlet.soffit.connector.SoffitConnectorController.RESPONSE_CACHE")
     private Cache responseCache;
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {


### PR DESCRIPTION
`SoffitConnectorController` is non-`final`, so might be extended. Such a sub-class could use this logger if `protected` rather than `private`, and probably should.
