### PR TITLE
Allow config for pooling connection

### DIFF
--- a/src/main/resources/org/apereo/portlet/soffit/mvc/soffit-connector.xml
+++ b/src/main/resources/org/apereo/portlet/soffit/mvc/soffit-connector.xml
@@ -16,4 +16,7 @@
     <context:annotation-config />
     <context:component-scan base-package="org.apereo.portlet.soffit.connector" />
 
+    <!-- Allows the SoffitConnectorController to benefit from uPortal's PlaceholderConfigurer -->
+    <bean parent="primaryPropertyPlaceholderConfigurer" />
+
 </beans>


### PR DESCRIPTION
Can now use properties for controlling the max number of connections per route and the total max connections for the PoolingHttpClientConnectionManager.
