### PR TITLE
Refactor: use ToStringBuilder in model toString() implementations.

### DIFF
--- a/src/main/java/org/apereo/portal/soffit/model/v1_0/Bearer.java
+++ b/src/main/java/org/apereo/portal/soffit/model/v1_0/Bearer.java
@@ -19,6 +19,8 @@
 
 package org.apereo.portal.soffit.model.v1_0;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -92,8 +94,12 @@ public class Bearer extends AbstractTokenizable {
 
     @Override
     public String toString() {
-        return "Bearer [username=" + username + ", attributes=" + attributes + ", groups=" + groups
-                + ", getEncryptedToken()=" + getEncryptedToken() + "]";
+        return new ToStringBuilder(this).
+            append("username", username).
+            append("attributes", attributes).
+            append("groups", groups).
+            append("getEncryptedToken()", this.getEncryptedToken()).
+            toString();
     }
 
 }

--- a/src/main/java/org/apereo/portal/soffit/model/v1_0/Definition.java
+++ b/src/main/java/org/apereo/portal/soffit/model/v1_0/Definition.java
@@ -19,6 +19,8 @@
 
 package org.apereo.portal.soffit.model.v1_0;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -118,8 +120,14 @@ public class Definition extends AbstractTokenizable {
 
     @Override
     public String toString() {
-        return "Definition [title=" + title + ", fname=" + fname + ", description=" + description + ", categories="
-                + categories + ", parameters=" + parameters + ", getEncryptedToken()=" + getEncryptedToken() + "]";
+        return new ToStringBuilder(this).
+            append("title", this.title).
+            append("fname", this.fname).
+            append("description", this.description).
+            append("categories", this.categories).
+            append("parameters", this.parameters).
+            append("getEncryptedToken()", this.getEncryptedToken()).
+            toString();
     }
 
 }

--- a/src/main/java/org/apereo/portal/soffit/model/v1_0/PortalRequest.java
+++ b/src/main/java/org/apereo/portal/soffit/model/v1_0/PortalRequest.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 /**
  * Provides some information about the user's request to which the portal will
  * respond using output from the soffit.  This information is organized into
@@ -189,8 +191,12 @@ public class PortalRequest extends AbstractTokenizable {
 
     @Override
     public String toString() {
-        return "PortalRequest [properties=" + properties + ", attributes=" + attributes + ", parameters=" + parameters
-                + ", getEncryptedToken()=" + getEncryptedToken() + "]";
+        return new ToStringBuilder(this).
+            append("properties", this.properties).
+            append("attributes", this.attributes).
+            append("parameters", this.parameters).
+            append("getEncryptedToken()", this.getEncryptedToken()).
+            toString();
     }
 
 }

--- a/src/main/java/org/apereo/portal/soffit/model/v1_0/Preferences.java
+++ b/src/main/java/org/apereo/portal/soffit/model/v1_0/Preferences.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 /**
  * Collection of preferences for this Soffit and their values.  Preferences are
  * typically defined by administrators at publish time.
@@ -73,7 +75,10 @@ public class Preferences extends AbstractTokenizable {
 
     @Override
     public String toString() {
-        return "Preferences [preferencesMap=" + preferencesMap + ", getEncryptedToken()=" + getEncryptedToken() + "]";
+        return new ToStringBuilder(this).
+            append("preferencesMap", this.preferencesMap).
+            append("getEncryptedToken()", this.getEncryptedToken()).
+            toString();
     }
 
 }


### PR DESCRIPTION
Spiritual successor to #19 .

Replaces ad-hoc `toString()` implementations in `Soffit` model classes with idiomatic use of Commons Lang 3 `ToStringBuilder`, retaining inclusion of `getEncryptedToken()` in the `toString()`.

Commons Lang 3 was already a dependency, so introduces no new dependencies.

All the unit tests still pass.

Improves readability, maintanability of `toString()` implementations and may set the stage for refactoring of `equals()` and `hashCode()` implementations.
