### PR TITLE
gradle-2.9-all not -bin as distributionUrl in gradle-wrapper.properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 09 08:47:58 MST 2016
+#Thu Jul 14 11:12:36 CDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip


### PR DESCRIPTION
IntelliJ prompted me to upgrade to `gradle-2.9-all` rather than `gradle-2.9-bin` for increased tooling salubrity.
